### PR TITLE
Fixed Resource ID example casing

### DIFF
--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -145,5 +145,5 @@ The following attributes are exported:
 App Service Plan instances can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_service_plan.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/serverfarms/instance1
+terraform import azurerm_app_service_plan.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/serverFarms/instance1
 ```


### PR DESCRIPTION
When using current example, the import fails. This is because in Resource ID serverfarms in the URL should be spelled with capital F letter - serverFarms.